### PR TITLE
Refresh deprecated Together serverless models

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "verify:models": "node scripts/verify-models.mjs",
     "db": "npx drizzle-kit push",
     "workflow": "npx @upstash/qstash-cli dev"
   },

--- a/scripts/verify-models.mjs
+++ b/scripts/verify-models.mjs
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const files = await Promise.all(
+  [
+    "../src/deepresearch/config.ts",
+    "../src/app/api/validate-key/route.ts",
+  ].map((path) => readFile(new URL(path, import.meta.url), "utf8")),
+);
+const modelConfiguration = files.join("\n");
+
+for (const removedModel of [
+  "MiniMaxAI/MiniMax-M2.7",
+  "Qwen/Qwen3-Next-80B-A3B-Instruct",
+  "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
+  "deepseek-ai/DeepSeek-V3.1",
+  "Qwen/Qwen3-235B-A22B-Instruct-2507-tput",
+  "zai-org/GLM-5",
+  "moonshotai/Kimi-K2.5",
+]) {
+  assert.ok(
+    !modelConfiguration.includes(removedModel),
+    `Removed model is still configured: ${removedModel}`,
+  );
+}
+
+for (const currentModel of [
+  "MiniMaxAI/MiniMax-M3",
+  "Qwen/Qwen3.5-9B",
+  "deepseek-ai/DeepSeek-V4-Pro",
+  "Qwen/Qwen3.7-Max",
+  "moonshotai/Kimi-K2.6",
+]) {
+  assert.ok(
+    modelConfiguration.includes(currentModel),
+    `Expected current model is missing: ${currentModel}`,
+  );
+}
+
+console.log("Open Deep Research only configures current serverless models.");

--- a/src/app/api/validate-key/route.ts
+++ b/src/app/api/validate-key/route.ts
@@ -15,7 +15,7 @@ export async function POST(request: Request) {
     const customClient = togetheraiClientWithKey(apiKey);
     // Make a simple LLM call to validate the API key
     await generateText({
-      model: customClient("moonshotai/Kimi-K2.5"),
+      model: customClient("Qwen/Qwen3.5-9B"),
       maxOutputTokens: 100,
       messages: [
         {

--- a/src/deepresearch/config.ts
+++ b/src/deepresearch/config.ts
@@ -11,28 +11,28 @@ import dedent from "dedent";
 // Specialized models for different stages of the research pipeline
 export const MODEL_CONFIG = {
   planningModel: "openai/gpt-oss-20b", // Used for research planning and evaluation // 128k context window
-  jsonModel: "Qwen/Qwen3-Next-80B-A3B-Instruct", // Used for structured data parsing
-  summaryModel: "Qwen/Qwen3-Next-80B-A3B-Instruct", // Used for web content summarization // 262k context window
-  summaryModelLongPages: "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8", // Used for web content summarization of long pages
+  jsonModel: "Qwen/Qwen3.5-9B", // Used for structured data parsing
+  summaryModel: "Qwen/Qwen3.5-9B", // Used for web content summarization // 262k context window
+  summaryModelLongPages: "MiniMaxAI/MiniMax-M3", // Used for web content summarization of long pages // 524k context window
 };
 
 // Available models for final report generation (user-selectable)
 export const AVAILABLE_MODELS = [
   {
-    value: "deepseek-ai/DeepSeek-V3.1",
-    label: "Deepseek V3.1",
+    value: "deepseek-ai/DeepSeek-V4-Pro",
+    label: "DeepSeek V4 Pro",
   },
   {
-    value: "MiniMaxAI/MiniMax-M2.7",
-    label: "MiniMax M2.7",
+    value: "MiniMaxAI/MiniMax-M3",
+    label: "MiniMax M3",
   },
   {
-    value: "Qwen/Qwen3-235B-A22B-Instruct-2507-tput",
-    label: "Qwen3",
+    value: "Qwen/Qwen3.7-Max",
+    label: "Qwen3.7 Max",
   },
   {
-    value: "zai-org/GLM-5",
-    label: "GLM 5",
+    value: "moonshotai/Kimi-K2.6",
+    label: "Kimi K2.6",
   },
 ] as const;
 


### PR DESCRIPTION
## Summary

- replace MiniMax M2.7 with MiniMax M3
- replace removed Qwen3 Next summary and JSON models with Qwen3.5 9B
- replace retired final-answer choices with current DeepSeek V4 Pro, Qwen3.7 Max, and Kimi K2.6 options
- use Qwen3.5 9B for API-key validation
- add a model lifecycle regression check

## Production evidence

Vercel recorded 14 model_not_available failures in seven days from Qwen/Qwen3-Next-80B-A3B-Instruct across active research chats.

## Verification

- pnpm verify:models
- Preview-configured Next.js production build
- all replacement IDs confirmed in the live Together catalog

This PR is prepared for review and has not been merged.