### PR TITLE
Add DeepSeek V4 Pro 0813 as a report model

### DIFF
--- a/scripts/verify-models.mjs
+++ b/scripts/verify-models.mjs
@@ -13,6 +13,7 @@ for (const currentModel of [
   "MiniMaxAI/MiniMax-M3",
   "Qwen/Qwen3.5-9B",
   "zai-org/GLM-5.2",
+  "deepseek-ai/DeepSeek-V4-Pro-0813",
   "Qwen/Qwen3.7-Max",
 ]) {
   assert.ok(

--- a/src/deepresearch/config.ts
+++ b/src/deepresearch/config.ts
@@ -23,6 +23,10 @@ export const AVAILABLE_MODELS = [
     label: "GLM 5.2",
   },
   {
+    value: "deepseek-ai/DeepSeek-V4-Pro-0813",
+    label: "DeepSeek V4 Pro 0813",
+  },
+  {
     value: "MiniMaxAI/MiniMax-M3",
     label: "MiniMax M3",
   },


### PR DESCRIPTION
## Summary

- add `deepseek-ai/DeepSeek-V4-Pro-0813` as an optional final-report model
- keep GLM 5.2 as the default
- extend the model-registry verification script

## Qualification

The exact model ID is live in Together's authenticated serverless catalog and completed direct inference.

Expanded old-vs-new capability suite:
- DeepSeek V4 Pro 0813: 12/12 passed
- previous DeepSeek V4 Pro: 9/12 passed
- 0813 passed forced tools, strict structured output, cited research, and fusion synthesis 3/3 each
- the previous model failed fusion synthesis 0/3

No deployment or merge is included.

## Validation

- cited-research qualification: 3/3
- full report generation produced valid inline citations
- model verification script: passed
- production build: passed